### PR TITLE
re-merge #2

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,9 +6,6 @@ cd build
 
 # # necessary to ensure the gobject-introspection-1.0 pkg-config file gets found
 # # meson needs this to determine where the g-ir-scanner script is located
-# export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$BUILD_PREFIX/lib/pkgconfig
-# export PKG_CONFIG=$BUILD_PREFIX/bin/pkg-config
-
 export PKG_CONFIG="${BUILD_PREFIX}/bin/pkg-config"
 export PKG_CONFIG_PATH="${BUILD_PREFIX}/lib/pkgconfig:${BUILD_PREFIX}/share/pkgconfig:${PREFIX}/lib/pkgconfig:${PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH:-}"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,10 +23,8 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - meson
-    - python
     - ninja-base
     - pkg-config
-    - setuptools
     - glib {{ glib }}
     - gobject-introspection
   host:


### PR DESCRIPTION
gcab 1.6 re-merge https://github.com/AnacondaRecipes/gcab-feedstock/pull/2

**Destination channel:** {defaults}

### Links

- https://anaconda.atlassian.net/browse/PKG-11095

- dev_url (recipe) | https://github.com/GNOME/gcab/tree/v1.6
- conda-forge | https://github.com/conda-forge/gcab-feedstock
- Anaconda Recipes | https://github.com/AnacondaRecipes/gcab-feedstock


### Explanation of changes:

- version updated 1.4 → 1.6
- added patch 0001-Explicitly-specify-gir-dir.patch
- rm osx disable-linker-script.patch
- build.sh cleaned, add -Dintrospection=true
- run deps switched to pin glib/zlib vars and gettext on osx
- tests added for library file, gir/typelib presence, and pkg-config gcab-1.0
