### PR TITLE
gcab-1.6-rebuild-vapi-enable

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,7 +17,7 @@ meson ${MESON_ARGS:-} \
   -Dintrospection=true \
   -Ddocs=false \
   -Dlibdir=lib \
-  -Dvapi=false ..
+  -Dvapi=true ..
 
 ninja
 ninja install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Explicitly-specify-gir-dir.patch
 
 build:
-  number: 0
+  number: 1
   # Not supported on win
   skip: true  # [win]
   run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - meson
+    - vala
     - ninja-base
     - pkg-config
     - glib {{ glib }}


### PR DESCRIPTION
gcab-1.6-rebuild-vapi-enable

**Destination channel:** {defaults}

### Links

- https://anaconda.atlassian.net/browse/PKG-12274
- dev_url (recipe) | https://github.com/GNOME/gcab/tree/v1.6
- conda-forge | https://github.com/conda-forge/gcab-feedstock
- Anaconda Recipes | https://github.com/AnacondaRecipes/gcab-feedstock


### Explanation of changes:

- vapi enable=true